### PR TITLE
Fix imports and docs about CSS imports by not specifying node_modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ __Option 2:__ If you want to override some of the styling, import it to a sass f
 
 ```scss
 // src/styles.scss
-@import "node_modules/ngx-tagify/styles/tagify";
+@import "ngx-tagify/styles/tagify";
 
 .tagify
   --tags-border-color: #ff0000;

--- a/projects/ngx-tagify/styles/tagify.scss
+++ b/projects/ngx-tagify/styles/tagify.scss
@@ -1,1 +1,1 @@
-@import "node_modules/@yaireo/tagify/src/tagify";
+@import "@yaireo/tagify/src/tagify";


### PR DESCRIPTION
In Angular, imports of CSS files from third party libraries should be done without specifying node_modules.

Specifying that folder makes it so applications fail to compile in Angular 16 with the new ESBuild feature.